### PR TITLE
docs: Fix ecommerce docker image name in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ docker pull erpya/adempiere-grpc-all-in-one
 docker pull erpya/proxy-adempiere-api
 ```
 
-Run the latest container with:
+Run the latest container with: https://hub.docker.com/r/erpya/adempiere-ecommerce
 ```shell
-    docker pull erpya/ecommerce
+    docker pull erpya/adempiere-ecommerce
 ```
 
 ```shell
 docker run -it -d \
     --name eCommerce-ADempiere \
-	-p 3000:3000 \
-	-e "API_URL=http:\/\/localhost:8085" \
-	-e "SERVER_PORT=3000" \
-	-e "VS_ENV=prod" \
-	erpya/ecommerce
+    -p 3000:3000 \
+    -e "API_URL=http:\/\/localhost:8085" \
+    -e "SERVER_PORT=3000" \
+    -e "VS_ENV=prod" \
+    erpya/adempiere-ecommerce
 ```


### PR DESCRIPTION
The name of the docker image is corrected in the documentation

The image `erpya/ecommerce` was used, but that image does not exist, so in the console it showed the error:

```shell
Using default tag: latest
Error response from daemon: pull access denied for erpya/ecommerce, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

Renamed docker image `erpya/adempiere-ecommerce`.